### PR TITLE
Minor test fixes

### DIFF
--- a/tests/check_redis.yml
+++ b/tests/check_redis.yml
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
 - name: Check if Redis responds
-  command: redis-cli PING | grep PONG
+  shell: redis-cli PING | grep PONG

--- a/tests/tests_sanity_fullstack.yml
+++ b/tests/tests_sanity_fullstack.yml
@@ -4,9 +4,12 @@
   hosts: all
 
   roles:
-    - performancecopilot.metrics.pcp
-    - performancecopilot.metrics.redis
-    - performancecopilot.metrics.grafana
+    - role: performancecopilot.metrics.pcp
+      vars:
+        pcp_rest_api: yes
+        pcp_pmproxy_localonly: 1
+    - role: performancecopilot.metrics.redis
+    - role: performancecopilot.metrics.grafana
 
   pre_tasks:
     - meta: end_host
@@ -27,7 +30,7 @@
         - check_redis.yml
         - check_pmproxy.yml
         - check_grafana.yml
-        - check_grafanapcp.yml
+        - check_grafana_pcp.yml
 
   post_tasks:
     - name: Restore state of services


### PR DESCRIPTION
- Fixed a typo in filename of check_grafana_pcp
- When running fullstack test - run the pmproxy localy only
- check_redis needs to be run in a shell as it uses pipe