### PR TITLE
Use Grafana provisioning mechanism to enable grafana-pcp

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,3 +1,4 @@
 ---
 skip_list:
 - '303'  # Using command rather than module for yum/dnf
+- ignore-errors

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.1"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -4,7 +4,7 @@ on:  # yamllint disable-line rule:truthy
   - pull_request
   - push
 env:
-  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.4.0"
+  TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.0"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pyver: ['2.7', '3.6', '3.7', '3.8']
+        pyver: ['2.7', '3.6', '3.7', '3.8', '3.9']
     steps:
       - name: checkout PR
         uses: actions/checkout@v2
@@ -37,9 +37,10 @@ jobs:
           toxpyver=$(echo "${{ matrix.pyver }}" | tr -d .)
           toxenvs="py${toxpyver}"
           case "$toxpyver" in
-          27) toxenvs="${toxenvs},coveralls,flake8,pylint,custom" ;;
-          36) toxenvs="${toxenvs},coveralls,black,yamllint,ansible-lint,shellcheck,custom,collection" ;;
-          37) toxenvs="${toxenvs},coveralls,custom" ;;
-          38) toxenvs="${toxenvs},coveralls,custom" ;;
+          27) toxenvs="${toxenvs},coveralls,flake8,pylint" ;;
+          36) toxenvs="${toxenvs},coveralls,black,yamllint,shellcheck" ;;
+          37) toxenvs="${toxenvs},coveralls" ;;
+          38) toxenvs="${toxenvs},coveralls,ansible-lint,ansible-plugin-scan,collection,ansible-test" ;;
+          39) toxenvs="${toxenvs},coveralls" ;;
           esac
           TOXENV="$toxenvs" lsr_ci_runtox

--- a/.github/workflows/tox.yml
+++ b/.github/workflows/tox.yml
@@ -5,6 +5,8 @@ on:  # yamllint disable-line rule:truthy
   - push
 env:
   TOX_LSR: "git+https://github.com/linux-system-roles/tox-lsr@2.7.1"
+  LSR_ROLE2COLL_NAMESPACE: "performancecopilot"
+  LSR_ROLE2COLL_NAME: "metrics"
   LSR_ANSIBLE_TEST_DOCKER: "true"
   LSR_ANSIBLES: 'ansible==2.9.*'
   LSR_MSCENARIOS: default

--- a/roles/grafana/files/grafana-pcp-provisioning.yaml
+++ b/roles/grafana/files/grafana-pcp-provisioning.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+
+apps:
+  - type: performancecopilot-pcp-app
+    org_id: 1
+    org_name: Performance Co-Pilot
+    disabled: false
+    jsonData:
+    secureJsonData:

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -46,8 +46,16 @@
     state: started
     enabled: yes
 
+- name: Get package facts now that Grafana is installed
+  package_facts:
+    manager: "auto"
+
+- name: Get Grafana version number from installed packages
+  set_fact:
+    grafana_version: "{{ ansible_facts.packages.grafana[0].version }}"
+
 # yamllint disable rule:line-length
-- name: Ensure graphing service runtime settings are configured
+- name: Ensure graphing service settings are configured by HTTP POST
   uri:
     url: "http://{{ __grafana_user }}:{{ __grafana_password }}@{{ __grafana_server }}/api/plugins/performancecopilot-pcp-app/settings"
     force_basic_auth: yes
@@ -55,4 +63,14 @@
       Content-Type: application/json
     method: POST
     src: files/grafana-pcp-settings.json
+  when: grafana_version is version('7.5.0', '<')
 # yamllint enable rule:line-length
+
+- name: Ensure graphing service settings are configured by provisioning
+  copy:
+    src: files/grafana-pcp-provisioning.yaml
+    dest: "{{ __grafana_provisioning_path }}/plugins/grafana-pcp.yaml"
+    owner: root
+    group: grafana
+    mode: '0640'
+  when: grafana_version is version('7.5.0', '>=')

--- a/scripts/lsrcollection.sh
+++ b/scripts/lsrcollection.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+TOPDIR=$(pwd)
+LSRDIR="ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
+mkdir -p "$TOX_WORK_DIR/$LSRDIR"
+cp -a "$TOPDIR"/* "$TOX_WORK_DIR/$LSRDIR"

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,11 @@
 [lsr_config]
 lsr_enable = true
 
+[testenv]
+setenv =
+    LSR_ROLE2COLL_NAMESPACE = performancecopilot
+    LSR_ROLE2COLL_NAME = metrics
+
 [lsr_ansible-lint]
 configfile = {toxinidir}/.ansible-lint
 
@@ -10,4 +15,5 @@ configfile = {toxinidir}/.yamllint.yml
 configbasename = .yamllint.yml
 
 [testenv:collection]
-commands = true
+commands =
+    bash scripts/lsrcollection.sh


### PR DESCRIPTION
If the available Grafana package installed by the role is of
version >= 7.5 we can use the plugins provisioning directory
and avoid interacting with Grafana (requiring credentials).

This is tested by the (existing) check_grafana_pcp.yml case.

Resolves Red Hat BZ #1967321