### PR TITLE
System Roles should consistently use ansible_managed in configuration files it manages

### DIFF
--- a/roles/bpftrace/templates/bpftrace.conf.j2
+++ b/roles/bpftrace/templates/bpftrace.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 #
 # PCP bpftrace PMDA config file - see pmdabpftrace(1) and PMDA(3)
 #

--- a/roles/elasticsearch/templates/elasticsearch.conf.j2
+++ b/roles/elasticsearch/templates/elasticsearch.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [pmda]
 user = pcp
 baseurl = http://localhost:{{ elasticsearch_agent_port }}/

--- a/roles/elasticsearch/templates/pcp2elasticsearch.service.j2
+++ b/roles/elasticsearch/templates/pcp2elasticsearch.service.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [Unit]
 Description=pcp-to-elasticsearch metrics export service
 Documentation=man:pcp2elasticsearch(1)

--- a/roles/grafana/templates/grafana-pcp-datasources.yaml.j2
+++ b/roles/grafana/templates/grafana-pcp-datasources.yaml.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 apiVersion: 1
 
 datasources:

--- a/roles/grafana/templates/grafana.ini.j2
+++ b/roles/grafana/templates/grafana.ini.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 ##################### Grafana Configuration Defaults #####################
 #
 # Do not modify this file in grafana installs

--- a/roles/mssql/templates/mssql.conf.j2
+++ b/roles/mssql/templates/mssql.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [connection]
 driver={ODBC Driver 17 for SQL Server}
 server=tcp:localhost

--- a/roles/pcp/templates/pmcd.defaults.j2
+++ b/roles/pcp/templates/pmcd.defaults.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Environment variables for the pmcd daemon.  Refer also to the
 # pmcd.options and pmcd.conf files for additional configuration.
 

--- a/roles/pcp/templates/pmcd.sasl2.conf.j2
+++ b/roles/pcp/templates/pmcd.sasl2.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Enabled authentication mechanisms (space-separated list).
 # You can list many mechanisms at once, then the user can choose
 # by adding e.g. '?authmech=gssapi' to their host specification.

--- a/roles/pcp/templates/pmie.control.j2
+++ b/roles/pcp/templates/pmie.control.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 $version=1.1
 #Host		P?  S?	Directory				  Arguments
 {{ item }}	n   n	PCP_LOG_DIR/pmie/{{ item }}/pmie.log	  -c config.{{ item }}

--- a/roles/pcp/templates/pmlogger.control.j2
+++ b/roles/pcp/templates/pmlogger.control.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 $version=1.1
 #Host			P? S?	directory		args
 {{ item }}	n n	PCP_ARCHIVE_DIR/{{ item }}	-r -T24h10m -c config.{{ item }} -v 100Mb

--- a/roles/pcp/templates/pmlogger.defaults.j2
+++ b/roles/pcp/templates/pmlogger.defaults.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Environment variables for the primary pmlogger daemon.  See also
 # the pmlogger control file and pmlogconf(1) for additional details.
 

--- a/roles/pcp/templates/pmlogger.timers.j2
+++ b/roles/pcp/templates/pmlogger.timers.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 ## Type:        string
 ## Default:	""
 #

--- a/roles/pcp/templates/pmproxy.defaults.j2
+++ b/roles/pcp/templates/pmproxy.defaults.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Environment variables for the pmproxy daemon.  Refer also to
 # the pmproxy.options file for additional configuration state.
 

--- a/roles/redis/templates/redis_5.conf.j2
+++ b/roles/redis/templates/redis_5.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Redis configuration file.
 #
 # Note on units: when memory size is needed, it is possible to specify

--- a/roles/redis/templates/redis_6.conf.j2
+++ b/roles/redis/templates/redis_6.conf.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 # Redis configuration file.
 #
 # Note on units: when memory size is needed, it is possible to specify

--- a/roles/repository/templates/artifactory.rpms.j2
+++ b/roles/repository/templates/artifactory.rpms.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [performancecpilot]
 name=Performance Co-Pilot
 baseurl=https://performancecopilot.jfrog.io/artifactory/pcp-rpm-release/{{ __repository_distro_name }}/$releasever/$basearch

--- a/roles/spark/templates/pcp2spark.service.j2
+++ b/roles/spark/templates/pcp2spark.service.j2
@@ -1,3 +1,4 @@
+{{ ansible_managed | comment }}
 [Unit]
 Description=pcp-to-spark metrics export service
 Documentation=man:pcp2spark(1)


### PR DESCRIPTION
bz#2044640

Add `{{ ansible_managed | comment }}` to the template files in
roles/*/templates except the files for .labels, .url and .debs.

Thank you for your comments in https://github.com/linux-system-roles/metrics/pull/107, @natoscott. I moved the changes to this pr.