### PR TITLE
Add "follow: yes" to the template task in the mssql and elasticsearch subrole.

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -45,6 +45,7 @@
   template:
     src: elasticsearch.conf.j2
     dest: "{{ __elasticsearch_conf }}"
+    follow: yes
     mode: 0600
   when:
     - elasticsearch_metrics_provider == 'pcp'

--- a/roles/mssql/tasks/main.yml
+++ b/roles/mssql/tasks/main.yml
@@ -34,6 +34,7 @@
   template:
     src: mssql.conf.j2
     dest: "{{ __mssql_conf }}"
+    follow: yes
     mode: 0600
   when: mssql_metrics_provider == 'pcp'
 


### PR DESCRIPTION
bz#2058655

The config files are symlinks targeting to the ones in /etc/pcp/subrole.
E.g.,
lrwxrwxrwx. ... /var/lib/pcp/pmdas/mssql/mssql.conf -> ../../../../../etc/pcp/mssql/mssql.conf

The "dest" path in the template module stores the symlink path, and the
symlink is not followed in the template module by default. That makes
the symlink a regular file, while it leaves the target intact.

Please note that bpftrace shares the similar issue, and it already has `follow: yes`.
https://github.com/performancecopilot/ansible-pcp/blob/main/roles/bpftrace/tasks/main.yml#L51