### PR TITLE
pmie - when pmie is configured, restart the service if it's already up.

### DIFF
--- a/roles/pcp/tasks/pmie.yml
+++ b/roles/pcp/tasks/pmie.yml
@@ -9,6 +9,7 @@
     group: root
     mode: 0755
   loop: "{{ __pcp_pmieconf_groups|default([]) }}"
+  register: __pcp_register_changed_group_dir
 
 - name: Ensure extra performance rule group link directories exist
   file:
@@ -18,6 +19,7 @@
     group: root
     mode: 0755
   loop: "{{ __pcp_pmieconf_groups|default([]) }}"
+  register: __pcp_register_changed_group_link_dir
 
 - name: Ensure extra performance rules are installed for targeted hosts
   copy:
@@ -27,6 +29,7 @@
     group: root
     mode: '0644'
   loop: "{{ __pcp_pmieconf_rules|default([]) }}"
+  register: __pcp_register_changed_rules_for_hosts
 
 - name: Ensure extra rules symlinks have been created for targeted hosts
   file:
@@ -35,6 +38,7 @@
     state: link
     force: yes
   loop: "{{ __pcp_pmieconf_rules|default([]) }}"
+  register: __pcp_register_changed_symlinks_for_hosts
 
 - name: Enable performance metric inference for targeted hosts (with control.d)
   template:
@@ -42,7 +46,7 @@
     dest: "{{ __pcp_pmie_control_d_path }}/{{ item }}"
     mode: 0644
   loop: "{{ pcp_target_hosts|default([]) }}"
-  notify: restart pmie
+  register: __pcp_register_changed_target_hosts_controld
   when:
     - not pcp_single_control|d(false)|bool
     - pcp_target_hosts|d([])
@@ -52,13 +56,32 @@
     src: pmie.control.j2
     dest: "{{ __pcp_pmie_control_path }}"
     mode: 0644
-  notify: restart pmie
+  register: __pcp_register_changed_target_hosts_single
   when:
     - pcp_single_control|d(true)|bool
     - pcp_target_hosts|d([])
+
+- name: Set variable to do pmie restart if needed
+  set_fact:
+    __pcp_restart_pmie: "{{
+      __pcp_register_changed_group_dir is changed or
+      __pcp_register_changed_group_link_dir is changed or
+      __pcp_register_changed_rules_for_hosts is changed or
+      __pcp_register_changed_symlinks_for_hosts is changed or
+      __pcp_register_changed_target_hosts_controld is changed or
+      __pcp_register_changed_target_hosts_single is changed
+    }}"
 
 - name: Ensure performance metric inference is running and enabled on boot
   service:
     name: pmie
     state: started
     enabled: yes
+  when: not __pcp_restart_pmie | bool
+
+- name: Ensure performance metric inference is restarted and enabled on boot
+  service:
+    name: pmie
+    state: restarted
+    enabled: yes
+  when: __pcp_restart_pmie | bool

--- a/roles/pcp/tasks/pmlogger.yml
+++ b/roles/pcp/tasks/pmlogger.yml
@@ -6,8 +6,8 @@
     path: "{{ __pcp_conf }}"
     regexp: '^PCP_ARCHIVE_DIR='
     line: PCP_ARCHIVE_DIR={{ pcp_archive_dir }}
+  register: __pcp_register_changed_log_location
   notify:
-    - restart pmlogger
     - restart pmproxy
 
 - name: Ensure performance metric logging is configured
@@ -15,13 +15,14 @@
     src: pmlogger.defaults.j2
     dest: "{{ __pcp_pmlogger_defaults_path }}"
     mode: 0644
-  notify: restart pmlogger
+  register: __pcp_register_changed_config_pmlogger
 
 - name: Ensure performance metric logging retention period is set
   template:
     src: pmlogger.timers.j2
     dest: "{{ __pcp_pmlogger_timers_path }}"
     mode: 0644
+  register: __pcp_register_changed_logging_retention_period
   notify: restart pmlogger
 
 - name: Enable performance metric logging for targeted hosts (with control.d)
@@ -30,6 +31,7 @@
     dest: "{{ __pcp_pmlogger_control_d_path }}/{{ item }}"
     mode: 0644
   loop: "{{ pcp_target_hosts|default([]) }}"
+  register: __pcp_register_changed_targeted_hosts_controld
   notify: restart pmlogger
   when:
     - not pcp_single_control|d(false)|bool
@@ -40,13 +42,31 @@
     src: pmlogger.control.j2
     dest: "{{ __pcp_pmlogger_control_path }}"
     mode: 0644
-  notify: restart pmlogger
+  register: __pcp_register_changed_targeted_hosts_single
   when:
     - pcp_single_control|d(true)|bool
     - pcp_target_hosts|d([])
+
+- name: Set variable to do pmlogger restart if needed
+  set_fact:
+    __pcp_restart_pmlogger: "{{
+      __pcp_register_changed_log_location is changed or
+      __pcp_register_changed_config_pmlogger is changed or
+      __pcp_register_changed_logging_retention_period is changed or
+      __pcp_register_changed_targeted_hosts_controld is changed or
+      __pcp_register_changed_targeted_hosts_single is changed
+    }}"
 
 - name: Ensure performance metric logging is running and enabled on boot
   service:
     name: pmlogger
     state: started
     enabled: yes
+  when: not __pcp_restart_pmlogger | bool
+
+- name: Ensure performance metric logging is restarted and enabled on boot
+  service:
+    name: pmlogger
+    state: restarted
+    enabled: yes
+  when: __pcp_restart_pmlogger | bool


### PR DESCRIPTION
We have an issue when we run the test playbooks in the metrics role from linux-system-role. The failed test case is to run the tests on a host where the control node and the managed node are shared. At the end of each test, the newly installed rpm packages in each test are removed and the state of services are reset. But still these tests fail:
```
tests_sanity_basic.yml
tests_sanity_fullstack.yml
tests_sanity_query.yml
tests_sanity_retention.yml
```
in `Check if primary pmie is running (metrics/tests/check_pmie.yml)` unless the pmie.service is restarted as in the diff.