### PR TITLE
Use "#noqa ignore_errors"

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,4 +1,3 @@
 ---
 skip_list:
 - '303'  # Using command rather than module for yum/dnf
-- ignore-errors

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -65,7 +65,7 @@
     name: pcp2elasticsearch
     state: started
     enabled: yes
-  ignore_errors: yes
+  ignore_errors: yes  # noqa ignore-errors
   # Elasticsearch server may be running remotely or presently down
   # but since a playbook has explicitly asked us for it, we end up
   # having to install our service ignoring any errors.

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -69,7 +69,7 @@
   # A given Spark server may be running remotely or presently down
   # but since a playbook has explicitly asked us for it, we end up
   # having to install our service ignoring any errors.
-  ignore_errors: yes
+  ignore_errors: yes  # noqa ignore-errors
   when:
     - spark_metrics_provider == 'pcp'
     - spark_export_metrics|d(false)|bool


### PR DESCRIPTION
Instead of setting "ignore_errors" in .ansible-lint globally, put "# noqa ignore-errors" on each task with "ignore_errors: yes".