### PR TITLE
galaxy.yml: build_ignore unnecessary files

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -32,11 +32,18 @@ tags:
   - redis
   - pcp
 build_ignore:
+  - .ansible-lint
   - .github
   - .gitignore
-  - .ansible-lint
-  - "*.yml"
-  - ".*.yaml"
+  - .lgtm.yml
+  - .yamllint.yml
+  - .yamllint_defaults.yml
+  - ansible_pytest_extra_requirements.txt
+  - custom_requirements.txt
+  - molecule_extra_requirements.txt
+  - pylint_extra_requirements.txt
+  - pytest_extra_requirements.txt
   - tests
+  - tox.ini
 
 dependencies: {}


### PR DESCRIPTION
Unfortunately, ansible-galaxy collection build includes every single file in the repository root by default. This adds `build_ignore`s for tests and other development files that cruft up the built collection artifact.

References: https://src.fedoraproject.org/rpms/ansible-pcp/pull-request/3

---

This is a modified version of the patch I submitted to the Fedora package. At some point, this should be replaced with the new [manifest directives feature](https://docs.ansible.com/ansible-core/devel/dev_guide/developing_collections_distributing.html#manifest-directives) that was added in core 2.14. Older versions of ansible will just ignore the `manifest` key if you add it to galaxy.yml (i.e. it won't break the build), but I still think we should stick to the more compatible solution.