### PR TITLE
Correction to naming of recent pmieconf vfs_rules configuration

### DIFF
--- a/roles/pcp/vars/main.yml
+++ b/roles/pcp/vars/main.yml
@@ -27,6 +27,7 @@ __pcp_pmieconf_groups:
   - network
   - power
   - zeroconf
+  - filesys
 
 __pcp_pmieconf_rules:
   - network/tcplistenoverflows
@@ -34,4 +35,4 @@ __pcp_pmieconf_rules:
   - network/tcpqfulldrops
   - power/thermal_throttle
   - zeroconf/all_threads
-  - filesys/vfs_rules
+  - filesys/vfs_files


### PR DESCRIPTION
Related to https://github.com/linux-system-roles/metrics/pull/133