### PR TITLE
fix additional ansible-lint issues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,6 +3,7 @@ skip_list:
   - fqcn-builtins
   - galaxy[no-changelog]
   - meta-unsupported-ansible
+  - meta-runtime[unsupported-version]
 exclude_paths:
   - tests/roles/
   - .github/

--- a/docs/bpftrace/setup.yml
+++ b/docs/bpftrace/setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: monitoring
+- name: Example of bpftrace
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.bpftrace
       vars:

--- a/docs/elasticsearch/setup.yml
+++ b/docs/elasticsearch/setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: monitoring
+- name: Example of elasticsearch
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.elasticsearch
       vars:

--- a/docs/grafana/setup.yml
+++ b/docs/grafana/setup.yml
@@ -1,4 +1,5 @@
 ---
-- hosts: all
+- name: Example of grafana
+  hosts: all
   roles:
     - role: performancecopilot.metrics.grafana

--- a/docs/mssql/basic.yml
+++ b/docs/mssql/basic.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: monitoring
+- name: Example of basic Microsoft SQL
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.mssql
       vars:

--- a/docs/mssql/secure.yml
+++ b/docs/mssql/secure.yml
@@ -1,4 +1,5 @@
 ---
-- hosts: monitoring
+- name: Example of secure Microsoft SQL
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.mssql

--- a/docs/pcp/farms.yml
+++ b/docs/pcp/farms.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: monitoring
+- name: Example of multiple target hosts
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.pcp
       vars:

--- a/docs/pcp/setup.yml
+++ b/docs/pcp/setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Example of basic pcp setup
+  hosts: all
   roles:
     - role: performancecopilot.metrics.pcp
       vars:

--- a/docs/pcp/users.yml
+++ b/docs/pcp/users.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: monitoring
+- name: Example of pcp with users
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.pcp
       vars:

--- a/docs/postfix/basic.yml
+++ b/docs/postfix/basic.yml
@@ -1,4 +1,5 @@
 ---
-- hosts: monitoring
+- name: Example of postfix
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.postfix

--- a/docs/redis/setup.yml
+++ b/docs/redis/setup.yml
@@ -1,4 +1,5 @@
 ---
-- hosts: all
+- name: Example of redis
+  hosts: all
   roles:
     - role: performancecopilot.metrics.redis

--- a/docs/repository/setup.yml
+++ b/docs/repository/setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: all
+- name: Example of repository
+  hosts: all
   roles:
     - role: performancecopilot.metrics.repository
     - role: performancecopilot.metrics.pcp

--- a/docs/spark/setup.yml
+++ b/docs/spark/setup.yml
@@ -1,5 +1,6 @@
 ---
-- hosts: monitoring
+- name: Example of spark
+  hosts: monitoring
   roles:
     - role: performancecopilot.metrics.spark
       vars:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: MIT
 ---
-requires_ansible: ">=2.7"
+requires_ansible: ">=2.9"

--- a/tests/check_pmlogger.yml
+++ b/tests/check_pmlogger.yml
@@ -10,3 +10,4 @@
   when: (ansible_facts['distribution'] in ['RedHat', 'CentOS'] and
          ansible_facts['distribution_major_version'] | int > 6) or
          ansible_facts['distribution'] not in ['Fedora', 'RedHat', 'CentOS']
+  changed_when: false


### PR DESCRIPTION
All plays must be named
Must use `changed_when` for `command` and `shell` with `when` also
For some reason ansible-lint does not like the `required_ansible` version
