### PR TITLE
docs: ansible-lint does not like version 2.9

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,8 +2,6 @@
 skip_list:
   - fqcn-builtins
   - galaxy[no-changelog]
-  - meta-unsupported-ansible
-  - meta-runtime[unsupported-version]
 exclude_paths:
   - tests/roles/
   - .github/

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: MIT
 ---
-requires_ansible: ">=2.9"
+requires_ansible: ">=2.11.0"


### PR DESCRIPTION
ansible-lint does not like version 2.9
Instead, use 2.11.0
Note that nothing really checks this, so we should be ok to
use 2.9 - the version only applies to ansible-core
