### PR TITLE
feat: Add a toggle to disable saving Redis database to disk

### DIFF
--- a/roles/redis/README.md
+++ b/roles/redis/README.md
@@ -8,7 +8,9 @@ Uses features of Redis v5+.  If the target platform provides it, the RediSearch 
 
 ## Role Variables
 
-None.
+    redis_save_to_disk: false
+
+Incrementally save the redis database to disk. Default: false.
 
 ## Dependencies
 

--- a/roles/redis/README.md
+++ b/roles/redis/README.md
@@ -8,9 +8,9 @@ Uses features of Redis v5+.  If the target platform provides it, the RediSearch 
 
 ## Role Variables
 
-    redis_save_to_disk: false
+    redis_save_to_disk: true
 
-Incrementally save the redis database to disk. Default: false.
+Incrementally save the redis database to disk. Default: true.
 
 ## Dependencies
 

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: MIT
 ---
-redis_save_to_disk: false
+redis_save_to_disk: true

--- a/roles/redis/defaults/main.yml
+++ b/roles/redis/defaults/main.yml
@@ -1,2 +1,3 @@
 # SPDX-License-Identifier: MIT
 ---
+redis_save_to_disk: false

--- a/roles/redis/templates/redis_5.conf.j2
+++ b/roles/redis/templates/redis_5.conf.j2
@@ -215,9 +215,13 @@ always-show-logo yes
 #
 #   save ""
 
+{% if redis_save_to_disk %}
 save 900 1
 save 300 10
 save 60 10000
+{% else %}
+save ""
+{% endif %}
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.

--- a/roles/redis/templates/redis_6.conf.j2
+++ b/roles/redis/templates/redis_6.conf.j2
@@ -285,9 +285,13 @@ always-show-logo yes
 #
 #   save ""
 
+{% if redis_save_to_disk %}
 save 900 1
 save 300 10
 save 60 10000
+{% else %}
+save ""
+{% endif %}
 
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.


### PR DESCRIPTION
# Enhancement

Adds a toggle to disable Redis' incremental save feature.

# Reason

Saving the Redis database seems unnecessary for the way `pmproxy` uses it. Disabling the save feature vastly reduces the CPU and I/O utilization of Redis.

# Result

Setting `redis_save_to_disk: false` causes Redis saves to be disabled.
