### PR TITLE
fix: ostree systems cannot write to /usr; use /etc instead

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -51,6 +51,20 @@
     - elasticsearch_metrics_provider == 'pcp'
     - elasticsearch_agent | d(false) | bool
 
+- name: Check if system is ostree
+  stat:
+    path: "{{ ostree_booted_file }}"
+  vars:
+    ostree_booted_file: /run/ostree-booted
+  register: __ostree_booted_stat
+
+- name: Ensure correct service path for ostree systems
+  when:
+    - __ostree_booted_stat.stat.exists
+    - __elasticsearch_service_path != "/etc/systemd/system"
+  set_fact:
+    __elasticsearch_service_path: /etc/systemd/system
+
 - name: Ensure PCP Elasticsearch export service exists
   template:
     src: pcp2elasticsearch.service.j2

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -52,6 +52,20 @@
     - spark_metrics_provider == 'pcp'
     - spark_metrics_agent | d(false) | bool
 
+- name: Check if system is ostree
+  stat:
+    path: "{{ ostree_booted_file }}"
+  vars:
+    ostree_booted_file: /run/ostree-booted
+  register: __ostree_booted_stat
+
+- name: Ensure correct service path for ostree systems
+  when:
+    - __ostree_booted_stat.stat.exists
+    - __spark_service_path != "/etc/systemd/system"
+  set_fact:
+    __spark_service_path: /etc/systemd/system
+
 - name: Ensure PCP Spark export service exists
   template:
     src: pcp2spark.service.j2


### PR DESCRIPTION
Use /etc/systemd/system instead of /usr/lib/systemd/system
for the elasticsearch service file on ostree systems.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
