### PR TITLE
feat: support for ostree systems

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -46,4 +46,5 @@ build_ignore:
   - tests
   - tox.ini
 
-dependencies: {}
+dependencies:
+  ansible.posix: '*'  # for rpm-ostree

--- a/roles/bpftrace/tasks/main.yml
+++ b/roles/bpftrace/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish bpftrace package names
   set_fact:
     __bpftrace_packages_extra: "{{ __bpftrace_packages +
@@ -32,6 +44,8 @@
   package:
     name: "{{ __bpftrace_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __bpftrace_packages_extra | d([])
 
 - name: Extract allowed bpftrace user accounts

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish Elasticsearch metrics package names
   set_fact:
     __elasticsearch_packages_extra: "{{ __elasticsearch_packages_extra +
@@ -32,6 +44,8 @@
   package:
     name: "{{ __elasticsearch_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __elasticsearch_packages_extra | d([])
 
 - name: Ensure PCP Elasticsearch agent configuration directory exists
@@ -51,16 +65,9 @@
     - elasticsearch_metrics_provider == 'pcp'
     - elasticsearch_agent | d(false) | bool
 
-- name: Check if system is ostree
-  stat:
-    path: "{{ ostree_booted_file }}"
-  vars:
-    ostree_booted_file: /run/ostree-booted
-  register: __ostree_booted_stat
-
 - name: Ensure correct service path for ostree systems
   when:
-    - __ostree_booted_stat.stat.exists
+    - __ansible_pcp_is_ostree | d(false)
     - __elasticsearch_service_path != "/etc/systemd/system"
   set_fact:
     __elasticsearch_service_path: /etc/systemd/system

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -12,10 +12,24 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Install Grafana packages
   package:
     name: "{{ __grafana_packages + __grafana_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Get package facts now that Grafana is installed
   package_facts:

--- a/roles/mssql/tasks/main.yml
+++ b/roles/mssql/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish SQL Server metrics package names
   set_fact:
     __mssql_packages_extra: "{{ __mssql_packages_pcp }}"
@@ -21,6 +33,8 @@
   package:
     name: "{{ __mssql_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __mssql_packages_extra | d([])
 
 - name: Ensure PCP SQL Server agent configuration directory exists

--- a/roles/pcp/tasks/main.yml
+++ b/roles/pcp/tasks/main.yml
@@ -12,15 +12,31 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Install Performance Co-Pilot packages
   package:
     name: "{{ __pcp_packages + __pcp_packages_extra + pcp_optional_packages }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Install authentication packages
   package:
     name: "{{ __pcp_sasl_packages }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
     - __pcp_sasl_packages | d([])
     - pcp_accounts | d({})

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish Postfix metrics package names
   set_fact:
     __postfix_packages_extra: "{{ __postfix_packages_pcp }}"
@@ -21,4 +33,6 @@
   package:
     name: "{{ __postfix_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __postfix_packages_extra | d([])

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -12,10 +12,24 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Install Redis packages
   package:
     name: "{{ __redis_packages + __redis_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
 - name: Ensure Redis configuration directory exists
   file:

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -12,6 +12,18 @@
   when: item is file
 # yamllint enable rule:line-length
 
+- name: Determine if system is ostree and set flag
+  when: not __ansible_pcp_is_ostree is defined
+  block:
+    - name: Check if system is ostree
+      stat:
+        path: /run/ostree-booted
+      register: __ostree_booted_stat
+
+    - name: Set flag to indicate system is ostree
+      set_fact:
+        __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
 - name: Establish Spark metrics package names
   set_fact:
     __spark_packages_extra: "{{ __spark_packages_extra +
@@ -32,6 +44,8 @@
   package:
     name: "{{ __spark_packages_extra }}"
     state: present
+    use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+             ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when: __spark_packages_extra | d([])
 
 - name: Ensure PCP OpenMetrics agent is configured for Spark
@@ -52,16 +66,9 @@
     - spark_metrics_provider == 'pcp'
     - spark_metrics_agent | d(false) | bool
 
-- name: Check if system is ostree
-  stat:
-    path: "{{ ostree_booted_file }}"
-  vars:
-    ostree_booted_file: /run/ostree-booted
-  register: __ostree_booted_stat
-
 - name: Ensure correct service path for ostree systems
   when:
-    - __ostree_booted_stat.stat.exists
+    - __ansible_pcp_is_ostree | d(false)
     - __spark_service_path != "/etc/systemd/system"
   set_fact:
     __spark_service_path: /etc/systemd/system

--- a/tests/tests_verify_mssql.yml
+++ b/tests/tests_verify_mssql.yml
@@ -20,10 +20,24 @@
     - name: Save state of services
       import_tasks: get_services_state.yml
 
+    - name: Determine if system is ostree and set flag
+      when: not __ansible_pcp_is_ostree is defined
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set flag to indicate system is ostree
+          set_fact:
+            __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
     - name: Ensure python3-pyodbc is installed
       package:
         name: python3-pyodbc
         state: present
+        use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+                ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
   tasks:
     - name: Check MSSQL functionality

--- a/tests/tests_verify_postfix.yml
+++ b/tests/tests_verify_postfix.yml
@@ -13,10 +13,24 @@
     - name: Save state of services
       import_tasks: get_services_state.yml
 
+    - name: Determine if system is ostree and set flag
+      when: not __ansible_pcp_is_ostree is defined
+      block:
+        - name: Check if system is ostree
+          stat:
+            path: /run/ostree-booted
+          register: __ostree_booted_stat
+
+        - name: Set flag to indicate system is ostree
+          set_fact:
+            __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
+
     - name: Ensure Postfix is installed
       package:
         name: postfix
         state: present
+        use: "{{ (__ansible_pcp_is_ostree | d(false)) |
+                ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
 
   tasks:
     - name: Check Postfix functionality


### PR DESCRIPTION
Feature: Allow running and testing the role with ostree managed nodes.

Reason: We have users who want to use the role to manage ostree
systems.

Result: Users can use the role to manage ostree managed nodes.

Add dependency on `ansible.posix` which provides the `rhel_rpm_ostree`
package manager.

When using the `package:` module, add `use:` to force the use of
the ostree package manager on ostree systems, and `omit` if not.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
