### PR TITLE
ci: use latest version of ansible-lint 2.16; fix lint issues

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: ci

--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -1,28 +1,37 @@
 ---
 name: Ansible Lint
 on:  # yamllint disable-line rule:truthy
+  merge_group:
+    branches:
+      - main
+    types:
+      - checks_requested
   pull_request:
   push:
     branches:
       - main
   workflow_dispatch:
+env:
+  LSR_ROLE2COLL_NAMESPACE: performancecopilot
+  LSR_ROLE2COLL_NAME: metrics
+  TOX_WORK_DIR: .tox
+permissions:
+  contents: read
 jobs:
   ansible_lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
-      - name: Fix up role meta/main.yml namespace and name
+      - name: Convert role to collection format
         run: |
           set -euxo pipefail
-          mm=meta/main.yml
-          if [ -f "$mm" ]; then
-            if ! grep -q '^  *namespace:' "$mm"; then
-              sed "/galaxy_info:/a\  namespace: performancecopilot" -i "$mm"
-            fi
-            if ! grep -q '^  *role_name:' "$mm"; then
-              sed "/galaxy_info:/a\  role_name: metrics" -i "$mm"
-            fi
-          fi
+          coll_dir="$TOX_WORK_DIR/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}"
+          bash scripts/lsrcollection.sh
+          # ansible-lint action requires a .git directory???
+          # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
+          mkdir -p "$coll_dir/.git"
       - name: Run ansible-lint
-        uses: ansible-community/ansible-lint-action@v6
+        uses: ansible/ansible-lint@v6
+        with:
+          working_directory: ${{ env.TOX_WORK_DIR }}/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,3 +1,3 @@
 # SPDX-License-Identifier: MIT
 ---
-requires_ansible: ">=2.11.0"
+requires_ansible: ">=2.13.0"

--- a/roles/bpftrace/tasks/main.yml
+++ b/roles/bpftrace/tasks/main.yml
@@ -58,13 +58,13 @@
   file:
     path: "{{ __bpftrace_conf_dir }}"
     state: directory
-    mode: 0755
+    mode: "0755"
   when: bpftrace_metrics_provider == 'pcp'
 
 - name: Ensure PCP bpftrace agent is configured
   template:
     src: bpftrace.conf.j2
     dest: "{{ __bpftrace_conf }}"
-    mode: 0600
+    mode: "0600"
     follow: true
   when: bpftrace_metrics_provider == 'pcp'

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -52,7 +52,7 @@
   file:
     path: "{{ __elasticsearch_conf_dir }}"
     state: directory
-    mode: 0755
+    mode: "0755"
   when: elasticsearch_metrics_provider == 'pcp'
 
 - name: Ensure PCP Elasticsearch agent is configured
@@ -60,7 +60,7 @@
     src: elasticsearch.conf.j2
     dest: "{{ __elasticsearch_conf }}"
     follow: true
-    mode: 0600
+    mode: "0600"
   when:
     - elasticsearch_metrics_provider == 'pcp'
     - elasticsearch_agent | d(false) | bool
@@ -76,7 +76,7 @@
   template:
     src: pcp2elasticsearch.service.j2
     dest: "{{ __elasticsearch_service_path }}/pcp2elasticsearch.service"
-    mode: 0600
+    mode: "0600"
   when:
     - elasticsearch_metrics_provider == 'pcp'
     - elasticsearch_export_metrics | d(false) | bool

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -42,7 +42,7 @@
   template:
     src: grafana_7.ini.j2
     dest: "{{ __grafana_conf }}"
-    mode: 0640
+    mode: "0640"
   notify: Restart grafana
   when: grafana_version is version('9.0.0', '<')
 
@@ -50,7 +50,7 @@
   template:
     src: grafana_9.ini.j2
     dest: "{{ __grafana_conf }}"
-    mode: 0640
+    mode: "0640"
   notify: Restart grafana
   when: grafana_version is version('9.0.0', '>=')
 
@@ -60,14 +60,13 @@
     state: directory
     group: grafana
     owner: root
-    mode: 0750
+    mode: "0750"
 
 - name: Ensure Grafana service is configured with datasources
   template:
     src: grafana-pcp-datasources.yaml.j2
     dest: "{{ __grafana_provisioning_path }}/datasources/grafana-pcp.yaml"
-
-    mode: 0644
+    mode: "0644"
   notify: Restart grafana
 
 - name: Ensure graphing service is running and enabled on boot
@@ -94,5 +93,5 @@
     dest: "{{ __grafana_provisioning_path }}/plugins/grafana-pcp.yaml"
     owner: root
     group: grafana
-    mode: '0640'
+    mode: "0640"
   when: grafana_version is version('7.5.0', '>=')

--- a/roles/mssql/tasks/main.yml
+++ b/roles/mssql/tasks/main.yml
@@ -41,7 +41,7 @@
   file:
     path: "{{ __mssql_conf_dir }}"
     state: directory
-    mode: 0755
+    mode: "0755"
   when: mssql_metrics_provider == 'pcp'
 
 - name: Ensure PCP SQL Server agent is configured
@@ -49,7 +49,7 @@
     src: mssql.conf.j2
     dest: "{{ __mssql_conf }}"
     follow: true
-    mode: 0600
+    mode: "0600"
   when: mssql_metrics_provider == 'pcp'
 
 - name: Ensure SQL Server performance rule group directory exists
@@ -58,7 +58,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   when: mssql_metrics_provider == 'pcp'
 
 - name: Ensure SQL Server performance rule group link directory exists
@@ -67,7 +67,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   when: mssql_metrics_provider == 'pcp'
 
 - name: Ensure SQL Server performance rules are installed for targeted hosts
@@ -76,7 +76,7 @@
     dest: "{{ __mssql_pmieconf_path }}/{{ item }}"
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   loop: "{{ __mssql_pmieconf_rules | default([]) }}"
   when: mssql_metrics_provider == 'pcp'
 

--- a/roles/pcp/tasks/pmcd.yml
+++ b/roles/pcp/tasks/pmcd.yml
@@ -24,7 +24,7 @@
   file:
     path: "{{ __pcp_explicit_labels_path }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
 
@@ -32,7 +32,7 @@
   file:
     path: "{{ __pcp_implicit_labels_path }}"
     state: directory
-    mode: 0755
+    mode: "0755"
     owner: root
     group: root
 
@@ -40,21 +40,21 @@
   template:
     src: pmcd.explicit.labels.j2
     dest: "{{ __pcp_explicit_labels_path }}/ansible-managed"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_explicit_labels
 
 - name: Ensure any implicit metric labels are configured
   template:
     src: pmcd.implicit.labels.j2
     dest: "{{ __pcp_implicit_labels_path }}/ansible-managed"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_implicit_labels
 
 - name: Ensure performance metric collector is configured
   template:
     src: pmcd.defaults.j2
     dest: "{{ __pcp_pmcd_defaults_path }}"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_defaults_config
 
 - name: Ensure performance metric collector system accounts are configured
@@ -87,7 +87,7 @@
   template:
     src: pmcd.sasl2.conf.j2
     dest: "{{ __pcp_pmcd_saslconf_path }}"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_authentication
   when: pcp_accounts | d([])
 

--- a/roles/pcp/tasks/pmie.yml
+++ b/roles/pcp/tasks/pmie.yml
@@ -7,7 +7,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   loop: "{{ __pcp_pmieconf_groups | default([]) }}"
   register: __pcp_register_changed_group_dir
 
@@ -17,7 +17,7 @@
     state: directory
     owner: root
     group: root
-    mode: 0755
+    mode: "0755"
   loop: "{{ __pcp_pmieconf_groups | default([]) }}"
   register: __pcp_register_changed_group_link_dir
 
@@ -27,7 +27,7 @@
     dest: "{{ __pcp_pmieconf_path }}/{{ item }}"
     owner: root
     group: root
-    mode: '0644'
+    mode: "0644"
   loop: "{{ __pcp_pmieconf_rules | default([]) }}"
   register: __pcp_register_changed_rules_for_hosts
 
@@ -96,7 +96,7 @@
   template:
     src: pmie.controld.j2
     dest: "{{ __pcp_pmie_control_d_path }}/{{ item }}"
-    mode: 0644
+    mode: "0644"
   loop: "{{ pcp_target_hosts | default([]) }}"
   register: __pcp_register_changed_target_hosts_controld
   when:
@@ -107,7 +107,7 @@
   template:
     src: pmie.control.j2
     dest: "{{ __pcp_pmie_control_path }}"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_target_hosts_single
   when:
     - pcp_single_control | d(true) | bool

--- a/roles/pcp/tasks/pmlogger.yml
+++ b/roles/pcp/tasks/pmlogger.yml
@@ -13,14 +13,14 @@
   template:
     src: pmlogger.defaults.j2
     dest: "{{ __pcp_pmlogger_defaults_path }}"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_config_pmlogger
 
 - name: Ensure performance metric logging retention period is set
   template:
     src: pmlogger.timers.j2
     dest: "{{ __pcp_pmlogger_timers_path }}"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_logging_retention_period
   notify: Restart pmlogger
 
@@ -28,7 +28,7 @@
   template:
     src: pmlogger.controld.j2
     dest: "{{ __pcp_pmlogger_control_d_path }}/{{ item }}"
-    mode: 0644
+    mode: "0644"
   loop: "{{ pcp_target_hosts | default([]) }}"
   register: __pcp_register_changed_targeted_hosts_controld
   notify: Restart pmlogger
@@ -40,7 +40,7 @@
   template:
     src: pmlogger.control.j2
     dest: "{{ __pcp_pmlogger_control_path }}"
-    mode: 0644
+    mode: "0644"
   register: __pcp_register_changed_targeted_hosts_single
   when:
     - pcp_single_control | d(true) | bool

--- a/roles/pcp/tasks/pmproxy.yml
+++ b/roles/pcp/tasks/pmproxy.yml
@@ -5,7 +5,7 @@
   template:
     src: pmproxy.defaults.j2
     dest: "{{ __pcp_pmproxy_defaults_path }}"
-    mode: 0644
+    mode: "0644"
   notify: Restart pmproxy
 
 - name: Ensure REST API, proxy and log discovery is running and enabled on boot

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -37,14 +37,14 @@
     state: directory
     owner: redis
     group: root
-    mode: 0750
+    mode: "0750"
 
 # yamllint disable rule:line-length
 - name: Ensure Redis service is configured
   template:
     src: "{{ item }}"
     dest: "{{ __redis_conf_path }}/{{ __redis_conf_file }}"
-    mode: 0640
+    mode: "0640"
     owner: redis
     group: root
   with_first_found:

--- a/roles/repository/tasks/main.yml
+++ b/roles/repository/tasks/main.yml
@@ -16,7 +16,7 @@
   template:
     src: artifactory.rpms.j2
     dest: /etc/yum.repos.d/performancecopilot.repo
-    mode: 0600
+    mode: "0600"
   when:
     - ansible_facts['os_family'] == 'RedHat'
 
@@ -24,6 +24,6 @@
   file:
     src: artifactory.debs.j2
     dest: /etc/apt/sources.list.d/performancecopilot.sources
-    mode: 0600
+    mode: "0600"
   when:
     - ansible_facts['os_family'] == 'Debian'

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -52,7 +52,7 @@
   template:
     src: spark.url.j2
     dest: "{{ __spark_metrics_conf }}"
-    mode: 0600
+    mode: "0600"
   when:
     - spark_metrics_provider == 'pcp'
     - spark_metrics_agent | d(false) | bool
@@ -77,7 +77,7 @@
   template:
     src: pcp2spark.service.j2
     dest: "{{ __spark_service_path }}/pcp2spark.service"
-    mode: 0600
+    mode: "0600"
   when:
     - spark_metrics_provider == 'pcp'
     - spark_export_metrics | d(false) | bool

--- a/scripts/lsrcollection.sh
+++ b/scripts/lsrcollection.sh
@@ -3,4 +3,4 @@
 TOPDIR=$(pwd)
 LSRDIR="ansible_collections/$LSR_ROLE2COLL_NAMESPACE/$LSR_ROLE2COLL_NAME"
 mkdir -p "$TOX_WORK_DIR/$LSRDIR"
-cp -a "$TOPDIR"/* "$TOX_WORK_DIR/$LSRDIR"
+cp -a "$TOPDIR"/* "$TOPDIR/.ansible-lint" "$TOX_WORK_DIR/$LSRDIR"


### PR DESCRIPTION
Use the latest supported ansible-lint github action which requires
conversion to collection.

Add dependabot checking for latest versions of github actions

Use `mode: "0NNN"` instead of `mode: 0NNN`.

ansible-test requires supported version `>= 2.13.0` even though the code
still supports earlier versions of ansible.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
