### PR TITLE
fix: Do not load RediSearch on non x86_64 Fedoras

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -6,9 +6,13 @@
   loop:
     - "{{ role_path }}/vars/default.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['os_family'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['os_family'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
   when: item is file
 # yamllint enable rule:line-length
 

--- a/roles/redis/vars/Fedora.yml
+++ b/roles/redis/vars/Fedora.yml
@@ -2,8 +2,5 @@
 ---
 # Put internal variables here with Fedora specific values.
 
-__redis_packages_extra:
-  - RediSearch
-
-__redis_loaded_modules:
-  - /usr/lib64/redis/modules/redisearch.so
+__redis_packages_extra: []
+__redis_loaded_modules: []

--- a/roles/redis/vars/Fedora_x86_64.yml
+++ b/roles/redis/vars/Fedora_x86_64.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Fedora on x86_64 specific values.
+
+__redis_packages_extra:
+  - RediSearch
+
+__redis_loaded_modules:
+  - /usr/lib64/redis/modules/redisearch.so


### PR DESCRIPTION
Non x86_64 builds of Redis do not support the RediSearch extension on Fedora distro. As such, use of the redis sub-role fails on non x86_64 architectures as the RediSearch is enforced on all architectures supported by Fedora.

This fix allows use of the RediSearch extension on Fedora distro, only when run on x86_64 architecture.

@richm can you please review this pull request ? There might be a better way how to achieve the required outcome and you are more experienced.