### PR TITLE
fix: do not restore non-installed services

### DIFF
--- a/tests/restore_services_state.yml
+++ b/tests/restore_services_state.yml
@@ -15,6 +15,7 @@
   when:
     - item + '.service' in final_state.ansible_facts.services
     - item + '.service' in initial_state.ansible_facts.services
+    - initial_state.ansible_facts.services[item + '.service'].status != "not-found"
   with_items:
     - pmcd
     - pmlogger


### PR DESCRIPTION
Some services might not be installed (i.e. redis) if a relevant subrole is not used (i.e. performancecopilot.metrics.redis). Thus an attempt to restore such a service fails. This commit adds a check for the service presence before its restoration.
