### PR TITLE
fix: add configuration files for c10s and el10

### DIFF
--- a/roles/bpftrace/vars/CentOS_10.yml
+++ b/roles/bpftrace/vars/CentOS_10.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__bpftrace_packages_pcp:
+  - pcp-pmda-bpftrace
+
+__bpftrace_packages:
+  - bpftrace

--- a/roles/bpftrace/vars/RedHat_10.yml
+++ b/roles/bpftrace/vars/RedHat_10.yml
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__bpftrace_packages_pcp:
+  - pcp-pmda-bpftrace
+
+__bpftrace_packages:
+  - bpftrace

--- a/roles/elasticsearch/vars/CentOS_10.yml
+++ b/roles/elasticsearch/vars/CentOS_10.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__elasticsearch_conf_dir: /etc/pcp/elasticsearch
+__elasticsearch_packages_export_pcp:
+  - pcp-export-pcp2elasticsearch
+  - pcp-system-tools

--- a/roles/elasticsearch/vars/RedHat_10.yml
+++ b/roles/elasticsearch/vars/RedHat_10.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__elasticsearch_conf_dir: /etc/pcp/elasticsearch
+__elasticsearch_packages_export_pcp:
+  - pcp-export-pcp2elasticsearch
+  - pcp-system-tools

--- a/roles/grafana/vars/CentOS_10.yml
+++ b/roles/grafana/vars/CentOS_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__grafana_packages_extra:
+  - grafana-pcp

--- a/roles/grafana/vars/RedHat_10.yml
+++ b/roles/grafana/vars/RedHat_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__grafana_packages_extra:
+  - grafana-pcp

--- a/roles/mssql/vars/CentOS_10.yml
+++ b/roles/mssql/vars/CentOS_10.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__mssql_conf_dir: /etc/pcp/mssql
+
+__mssql_packages_pcp:
+  - pcp-pmda-mssql

--- a/roles/mssql/vars/RedHat_10.yml
+++ b/roles/mssql/vars/RedHat_10.yml
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__mssql_conf_dir: /etc/pcp/mssql
+
+__mssql_packages_pcp:
+  - pcp-pmda-mssql

--- a/roles/pcp/vars/CentOS_10.yml
+++ b/roles/pcp/vars/CentOS_10.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__pcp_packages_extra:
+  - pcp-zeroconf
+
+__pcp_sasl_packages:
+  - cyrus-sasl-lib
+  - cyrus-sasl-scram
+
+__pcp_sasl_mechlist: scram-sha-256

--- a/roles/pcp/vars/RedHat_10.yml
+++ b/roles/pcp/vars/RedHat_10.yml
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__pcp_packages_extra:
+  - pcp-zeroconf
+
+__pcp_sasl_packages:
+  - cyrus-sasl-lib
+  - cyrus-sasl-scram
+
+__pcp_sasl_mechlist: scram-sha-256

--- a/roles/redis/vars/CentOS_10.yml
+++ b/roles/redis/vars/CentOS_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__redis_packages_extra: []
+__redis_loaded_modules: []

--- a/roles/redis/vars/RedHat_10.yml
+++ b/roles/redis/vars/RedHat_10.yml
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__redis_packages_extra: []
+__redis_loaded_modules: []

--- a/roles/spark/vars/CentOS_10.yml
+++ b/roles/spark/vars/CentOS_10.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with CentOS 10 specific values.
+
+__spark_packages_export_pcp:
+  - pcp-export-pcp2spark
+  - pcp-system-tools

--- a/roles/spark/vars/RedHat_10.yml
+++ b/roles/spark/vars/RedHat_10.yml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+---
+# Put internal variables here with Red Hat Enterprise Linux 10 specific values.
+
+__spark_packages_export_pcp:
+  - pcp-export-pcp2spark
+  - pcp-system-tools


### PR DESCRIPTION
Enhancement: Start ansible-pcp porting to el10

Reason: Missing config files and likely other issues

Result: ansible-pcp works on el10

Issue Tracker Tickets (Jira or BZ if any):
https://issues.redhat.com/browse/SYSROLES-67