### PR TITLE
fix: add support for EL10

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -11,10 +11,6 @@ on:  # yamllint disable-line rule:truthy
     branches:
       - main
   workflow_dispatch:
-env:
-  LSR_ROLE2COLL_NAMESPACE: performancecopilot
-  LSR_ROLE2COLL_NAME: metrics
-  TOX_WORK_DIR: .tox
 permissions:
   contents: read
 jobs:
@@ -23,15 +19,5 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
-      - name: Convert role to collection format
-        run: |
-          set -euxo pipefail
-          coll_dir="$TOX_WORK_DIR/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}"
-          bash scripts/lsrcollection.sh
-          # ansible-lint action requires a .git directory???
-          # https://github.com/ansible/ansible-lint/blob/main/action.yml#L45
-          mkdir -p "$coll_dir/.git"
       - name: Run ansible-lint
         uses: ansible/ansible-lint@v24
-        with:
-          working_directory: ${{ env.TOX_WORK_DIR }}/ansible_collections/${{ env.LSR_ROLE2COLL_NAMESPACE }}/${{ env.LSR_ROLE2COLL_NAME }}

--- a/roles/bpftrace/meta/main.yml
+++ b/roles/bpftrace/meta/main.yml
@@ -33,3 +33,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/elasticsearch/meta/main.yml
+++ b/roles/elasticsearch/meta/main.yml
@@ -33,3 +33,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/grafana/meta/main.yml
+++ b/roles/grafana/meta/main.yml
@@ -33,3 +33,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/mssql/meta/main.yml
+++ b/roles/mssql/meta/main.yml
@@ -33,3 +33,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/pcp/meta/main.yml
+++ b/roles/pcp/meta/main.yml
@@ -32,3 +32,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/postfix/meta/main.yml
+++ b/roles/postfix/meta/main.yml
@@ -33,3 +33,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -35,3 +35,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/repository/meta/main.yml
+++ b/roles/repository/meta/main.yml
@@ -28,3 +28,7 @@ galaxy_info:
     - packaging
     - monitoring
     - performance
+    - el
+    - fedora
+    - debian
+    - ubuntu

--- a/roles/spark/meta/main.yml
+++ b/roles/spark/meta/main.yml
@@ -32,3 +32,7 @@ galaxy_info:
     - lightweight
     - visualization
     - instrumentation
+    - el
+    - fedora
+    - debian
+    - ubuntu


### PR DESCRIPTION
According to the Ansible team, support for listing platforms in
role `meta/main.yml` files is being removed.
Instead, they recommend using `galaxy_tags`

https://github.com/ansible/ansible/blob/stable-2.17/changelogs/CHANGELOG-v2.17.rst
"Remove the galaxy_info field platforms from the role templates"
https://github.com/ansible/ansible/issues/82453

Many roles already have tags such as "rhel", "redhat", "centos", and "fedora".
I propose that we ensure all of the system roles have these tags.
Some of our roles support Suse, Debian, Ubuntu, and others.
We should add tags for those e.g. the ssh role already has tags for "debian" and "ubuntu".

In addition - for each version listed under `platforms.EL` - add a tag like `elN`.

Q: Why not use a delimiter between the platform and the version e.g. `el-10`?

This is not allowed by ansible-lint:

```
meta-no-tags: Tags must contain lowercase letters and digits only., invalid: 'el-10'
meta/main.yml:1
```

So we cannot use uppercase letters either.

Q: Why not use our own meta/main.yml field?

No other fields are allowed by ansible-lint:

```
syntax-check[specific]: 'myfield' is not a valid attribute for a RoleMetadata
```

Q: Why not use some other field?

There are no other applicable or suitable fields.

Q: What happens when we want to support versions like `N.M`?

Use the word "dot" instead of "." e.g. `el10dot3`.
Similarly - use "dash" instead of "-".

We do not need tags such as `fedoraall`.
The `fedora` tag implies that the role works on all supported versions of fedora.
Otherwise, use tags such as `fedora40` if the role only supports specific versions.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
