### PR TITLE
ci: use env var for PR title; rename to pr-title-lint

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,5 +1,4 @@
----
-name: Commitlint
+name: PR Title Lint
 on:  # yamllint disable-line rule:truthy
   pull_request:
     types:
@@ -26,6 +25,7 @@ jobs:
         run: npm install @commitlint/config-conventional @commitlint/cli
 
       - name: Run commitlint on PR title
-        run: >-
-          echo '${{ github.event.pull_request.title }}' |
-          npx commitlint --verbose
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        # Echo from env variable to avoid bash errors with extra characters
+        run: echo "$PR_TITLE" | npx commitlint --verbose


### PR DESCRIPTION
In accordance with

https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable

Use an env var for the PR title in the checker

Rename the action because it only checks the PR title, not the
commits.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
