### PR TITLE
fix: Fixed usage of architecture in the redis sub-role

### DIFF
--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -6,13 +6,13 @@
   loop:
     - "{{ role_path }}/vars/default.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['os_family'] }}.yml"
-    - "{{ role_path }}/vars/{{ ansible_facts['os_family'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['os_family'] }}_{{ ansible_facts['architecture'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}.yml"
-    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['architecture'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}.yml"
-    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_major_version'] }}_{{ ansible_facts['architecture'] }}.yml"
     - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}.yml"
-    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}_{{ ansible_facts['ansible_architecture'] }}.yml"
+    - "{{ role_path }}/vars/{{ ansible_facts['distribution'] }}_{{ ansible_facts['distribution_version'] }}_{{ ansible_facts['architecture'] }}.yml"
   when: item is file
 # yamllint enable rule:line-length
 


### PR DESCRIPTION
`ansible_facts['ansible_architecture']` replaced with `ansible_facts['architecture']`