### PR TITLE
fix: older versions of RHEL (pre-10) need to use redis package

### DIFF
--- a/roles/keyserver/vars/RedHat_6.yml
+++ b/roles/keyserver/vars/RedHat_6.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with Red Hat Enterprise Linux 6 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []

--- a/roles/keyserver/vars/RedHat_7.yml
+++ b/roles/keyserver/vars/RedHat_7.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with Red Hat Enterprise Linux 7 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []

--- a/roles/keyserver/vars/RedHat_8.yml
+++ b/roles/keyserver/vars/RedHat_8.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with Red Hat Enterprise Linux 8 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []

--- a/roles/keyserver/vars/RedHat_9.yml
+++ b/roles/keyserver/vars/RedHat_9.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with Red Hat Enterprise Linux 9 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []


### PR DESCRIPTION
A fallthrough was accidentally picking up valkey package name for these older RHEL releases - that's correct for Fedora and RHEL-10 onward, but not earlier RHEL releases.

Enhancement:

Reason:

Result:

Issue Tracker Tickets (Jira or BZ if any):
