### PR TITLE
fix: older versions of Centos (pre-10) need to use redis package

### DIFF
--- a/roles/keyserver/vars/CentOS_6.yml
+++ b/roles/keyserver/vars/CentOS_6.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with CentOS 6 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []

--- a/roles/keyserver/vars/CentOS_7.yml
+++ b/roles/keyserver/vars/CentOS_7.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with CentOS 7 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []

--- a/roles/keyserver/vars/CentOS_8.yml
+++ b/roles/keyserver/vars/CentOS_8.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with CentOS 8 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []

--- a/roles/keyserver/vars/CentOS_9.yml
+++ b/roles/keyserver/vars/CentOS_9.yml
@@ -3,6 +3,7 @@
 # Put internal variables here with CentOS 9 specific values.
 
 __keyserver_name: redis
+__keyserver_packages: redis
 __keyserver_conf_path: /etc/redis
 __keyserver_conf_file: redis.conf
 __keyserver_packages_extra: []


### PR DESCRIPTION
A fallthrough was accidentally picking up valkey package name for these older RHEL releases - that's correct for Fedora and RHEL-10 onward, but not earlier RHEL releases.