### PR TITLE
fix: use __grafana_keyserver_datasource_type variable instead of its string value

### DIFF
--- a/roles/grafana/templates/grafana_9.ini.j2
+++ b/roles/grafana/templates/grafana_9.ini.j2
@@ -1030,7 +1030,7 @@ min_refresh_interval = 1s
 ;enable_alpha = false
 ;app_tls_skip_verify_insecure = false
 # Enter a comma-separated list of plugin identifiers to identify plugins to load even if they are unsigned. Plugins with modified signatures are never loaded.
-allow_loading_unsigned_plugins = performancecopilot-pcp-app,{{ __grafana_keyserver_datasource_type }},pcp-vector-datasource,pcp-bpftrace-datasource,pcp-flamegraph-panel,pcp-breadcrumbs-panel,pcp-troubleshooting-panel,{{ performancecopilot-valkey-datasource }},performancecopilot-vector-datasource,performancecopilot-bpftrace-datasource,performancecopilot-flamegraph-panel,performancecopilot-breadcrumbs-panel,performancecopilot-troubleshooting-panel
+allow_loading_unsigned_plugins = performancecopilot-pcp-app,{{ __grafana_keyserver_datasource_type }},pcp-vector-datasource,pcp-bpftrace-datasource,pcp-flamegraph-panel,pcp-breadcrumbs-panel,pcp-troubleshooting-panel,{{ __grafana_keyserver_datasource_alttype }},performancecopilot-vector-datasource,performancecopilot-bpftrace-datasource,performancecopilot-flamegraph-panel,performancecopilot-breadcrumbs-panel,performancecopilot-troubleshooting-panel
 # Enable or disable installing / uninstalling / updating plugins directly from within Grafana.
 ;plugin_admin_enabled = false
 ;plugin_admin_external_manage_enabled = false


### PR DESCRIPTION
I think this line is supposed to use `{{ __grafana_keyserver_datasource_alttype }}`
like the grafana_7.ini.j2 template.  At any rate,
`{{ performancecopilot-valkey-datasource }}` is not a variable, and not even a
valid variable name (cannot have `-` in a variable name.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
