### PR TITLE
fix: no pcp-pmda-openmetrics on EL7

### DIFF
--- a/docs/pcp/setup.yml
+++ b/docs/pcp/setup.yml
@@ -6,6 +6,7 @@
       vars:
         pcp_pmie_endpoint: https://example.com/webhook
         pcp_pmlogger_interval: 10
+        # NOTE: No openmetrics on EL7
         pcp_optional_agents: [dm, nfsclient, openmetrics]
         pcp_explicit_labels:
           environment: production

--- a/roles/pcp/README.md
+++ b/roles/pcp/README.md
@@ -89,6 +89,7 @@ Basic PCP setup with monitoring suited for a single host.
     - role: performancecopilot.metrics.pcp
       vars:
         pcp_pmlogger_interval: 10
+        # NOTE: No openmetrics on EL7
         pcp_optional_agents: [dm, nfsclient, openmetrics]
         pcp_explicit_labels:
           environment: production

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -56,6 +56,7 @@
   when:
     - spark_metrics_provider == 'pcp'
     - spark_metrics_agent | d(false) | bool
+    - "'pcp-pmda-openmetrics' in __spark_packages_pcp"
 
 - name: Ensure PCP OpenMetrics agent is enabled with Spark endpoint
   file:
@@ -65,6 +66,7 @@
   when:
     - spark_metrics_provider == 'pcp'
     - spark_metrics_agent | d(false) | bool
+    - "'pcp-pmda-openmetrics' in __spark_packages_pcp"
 
 - name: Ensure correct service path for ostree systems
   when:

--- a/roles/spark/vars/CentOS_7.yml
+++ b/roles/spark/vars/CentOS_7.yml
@@ -5,3 +5,5 @@
 __spark_packages_export_pcp:
   - pcp-export-pcp2spark
   - pcp-system-tools
+
+__spark_packages_pcp: []

--- a/roles/spark/vars/RedHat_7.yml
+++ b/roles/spark/vars/RedHat_7.yml
@@ -5,3 +5,5 @@
 __spark_packages_export_pcp:
   - pcp-export-pcp2spark
   - pcp-system-tools
+
+__spark_packages_pcp: []


### PR DESCRIPTION
There is no pcp-pmda-openmetrics package on EL7, so ensure
the spark role works in that case.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
