### PR TITLE
fix: Fix non-boolean conditions

### DIFF
--- a/roles/bpftrace/tasks/main.yml
+++ b/roles/bpftrace/tasks/main.yml
@@ -30,7 +30,7 @@
                                 __bpftrace_packages_extra }}"
   when:
     - bpftrace_metrics_provider == 'pcp'
-    - __bpftrace_packages_pcp | d([])
+    - __bpftrace_packages_pcp | d([]) | length > 0
 
 - name: Establish bpftrace metrics package names
   set_fact:
@@ -38,7 +38,7 @@
                                 __bpftrace_packages_extra }}"
   when:
     - bpftrace_metrics_provider == 'pcp'
-    - __bpftrace_packages_pcp | d([])
+    - __bpftrace_packages_pcp | d([]) | length > 0
 
 - name: Install needed bpftrace metrics packages
   package:
@@ -46,7 +46,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __bpftrace_packages_extra | d([])
+  when: __bpftrace_packages_extra | d([]) | length > 0
 
 - name: Extract allowed bpftrace user accounts
   set_fact:

--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -46,7 +46,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __elasticsearch_packages_extra | d([])
+  when: __elasticsearch_packages_extra | d([]) | length > 0
 
 - name: Ensure PCP Elasticsearch agent configuration directory exists
   file:

--- a/roles/mssql/tasks/main.yml
+++ b/roles/mssql/tasks/main.yml
@@ -35,7 +35,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __mssql_packages_extra | d([])
+  when: __mssql_packages_extra | d([]) | length > 0
 
 - name: Ensure PCP SQL Server agent configuration directory exists
   file:

--- a/roles/pcp/tasks/main.yml
+++ b/roles/pcp/tasks/main.yml
@@ -38,8 +38,8 @@
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
   when:
-    - __pcp_sasl_packages | d([])
-    - pcp_accounts | d({})
+    - __pcp_sasl_packages | d([]) | length > 0
+    - pcp_accounts | d([]) | length > 0
 
 - name: Include pmcd
   include_tasks: pmcd.yml

--- a/roles/pcp/tasks/pmcd.yml
+++ b/roles/pcp/tasks/pmcd.yml
@@ -89,7 +89,7 @@
     dest: "{{ __pcp_pmcd_saslconf_path }}"
     mode: "0644"
   register: __pcp_register_changed_authentication
-  when: pcp_accounts | d([])
+  when: pcp_accounts | d([]) | length > 0
 
 - name: Set variable to do pmcd restart if needed
   set_fact:

--- a/roles/pcp/tasks/pmie.yml
+++ b/roles/pcp/tasks/pmie.yml
@@ -101,7 +101,7 @@
   register: __pcp_register_changed_target_hosts_controld
   when:
     - not pcp_single_control | d(false) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Enable performance metric inference for targeted hosts (single control)
   template:
@@ -111,7 +111,7 @@
   register: __pcp_register_changed_target_hosts_single
   when:
     - pcp_single_control | d(true) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Set variable to do pmie restart if needed
   set_fact:

--- a/roles/pcp/tasks/pmlogger.yml
+++ b/roles/pcp/tasks/pmlogger.yml
@@ -34,7 +34,7 @@
   notify: Restart pmlogger
   when:
     - not pcp_single_control | d(false) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Enable performance metric logging for targeted hosts (single control)
   template:
@@ -44,7 +44,7 @@
   register: __pcp_register_changed_targeted_hosts_single
   when:
     - pcp_single_control | d(true) | bool
-    - pcp_target_hosts | d([])
+    - pcp_target_hosts | d([]) | length > 0
 
 - name: Set variable to do pmlogger restart if needed
   set_fact:

--- a/roles/postfix/tasks/main.yml
+++ b/roles/postfix/tasks/main.yml
@@ -35,4 +35,4 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __postfix_packages_extra | d([])
+  when: __postfix_packages_extra | d([]) | length > 0

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -46,7 +46,7 @@
     state: present
     use: "{{ (__ansible_pcp_is_ostree | d(false)) |
              ternary('ansible.posix.rhel_rpm_ostree', omit) }}"
-  when: __spark_packages_extra | d([])
+  when: __spark_packages_extra | d([]) | length > 0
 
 - name: Ensure PCP OpenMetrics agent is configured for Spark
   template:


### PR DESCRIPTION
Ansible 2.19 demands conditions (`when:` or `assert:`) to have a boolean type. Fix list-value conditions with an explicit length check.

Also fix the `pcp_accounts` default value in roles/pcp/tasks/main.yml -- that variable is a list (of objects), not an object.

----

This fixes the [Ansible 2.19 specific errors](https://dl.fedoraproject.org/pub/alt/linuxsystemroles/logs/tf_metrics-173_Fedora-42-2.19_20250621-101911/artifacts/) like

> [ERROR]: Task failed: Action failed: {'failed': True, 'exception': '(traceback unavailable)', 'msg': 'Task failed: Conditional result was "[\'cyrus-sasl-lib\', \'cyrus-sasl-scram\']" of type \'list\', which evaluates to True. Conditionals must have a boolean result.', 'changed': False, '_ansible_no_log': False}

I tested them against https://github.com/linux-system-roles/metrics, I'll post a draft PR soon. Note that this still leaves one Fedora 42 failure in `tests_verify_from_spark.yml` which is unrelated, it's an SELinux rejection.

@richm FYI