### PR TITLE
fix: pmie webhook configuration for unconfigured system

### DIFF
--- a/roles/pcp/tasks/pmie.yml
+++ b/roles/pcp/tasks/pmie.yml
@@ -53,10 +53,10 @@
   loop: "{{ __pcp_global_webhook_action_status.results }}"
   changed_when:
     - pcp_pmie_endpoint | length > 0
-    - item.found | d(-1) == 0
+    - item.found | d(-1) <= 0
   when:
     - pcp_pmie_endpoint | length > 0
-    - item.found | d(-1) == 0
+    - item.found | d(-1) <= 0
   register: __pcp_register_changed_actions_for_hosts
   # yamllint enable rule:line-length
 
@@ -76,10 +76,10 @@
   loop: "{{ __pcp_global_webhook_endpoint_status.results }}"
   changed_when:
     - pcp_pmie_endpoint | length > 0
-    - item.found | d(-1) == 0
+    - item.found | d(-1) <= 0
   when:
     - pcp_pmie_endpoint | length > 0
-    - item.found | d(-1) == 0
+    - item.found | d(-1) <= 0
   register: __pcp_register_changed_actions_for_hosts
   # yamllint enable rule:line-length
 


### PR DESCRIPTION
If pmie never ran before, then /var/lib/pcp/config/pmie/config.default does not exist, and the `lineinfile` check mode gives `item.found == -1` instead of `0`. In that case we still want to configure the webhook.

This was previously hidden as the tests run on an unclean VM (from previous tests) which caused the config file to be written. But it fails when either running linux-system-roles/metrics'
tests_verify_notification.yml in isolation, or running against a container build target where services don't run.

---

Reproducer in the system role:
```
tox -e qemu-ansible-core-2.17 -- --image-name centos-10 --log-level=debug tests/tests_verify_notification.yml
```

If you run verify_pmie_webhook first, it works:

```
tox -e qemu-ansible-core-2.17 -- --image-name centos-10 --log-level=debug tests/tests_verify_pmie_webhook.yml tests/tests_verify_notification.yml
```

Found in my [initial bootc support runs](https://github.com/martinpitt/lsr-metrics/actions/runs/15821669129).