### PR TITLE
fix: Skip runtime service operations for non-booted hosts

### DIFF
--- a/roles/elasticsearch/tasks/main.yml
+++ b/roles/elasticsearch/tasks/main.yml
@@ -81,10 +81,23 @@
     - elasticsearch_metrics_provider == 'pcp'
     - elasticsearch_export_metrics | d(false) | bool
 
+- name: Determine if host is booted
+  # noqa command-instead-of-module
+  command: systemctl is-system-running
+  register: __system_running
+  changed_when: false
+  check_mode: false
+  failed_when: false
+
+- name: Require installed systemd
+  fail:
+    msg: "Error: This role requires systemd to be installed."
+  when: '"No such file or directory" in __system_running.msg | d("")'
+
 - name: Ensure PCP Elasticsearch export is running and enabled on boot
   service:
     name: pcp2elasticsearch
-    state: started
+    state: "{{ 'started' if __system_running.stdout != 'offline' else omit }}"
     enabled: true
   ignore_errors: true  # noqa ignore-errors
   # Elasticsearch server may be running remotely or presently down

--- a/roles/grafana/handlers/main.yml
+++ b/roles/grafana/handlers/main.yml
@@ -5,3 +5,4 @@
   service:
     name: grafana-server
     state: restarted
+  when: __grafana_is_booted | bool

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -24,6 +24,23 @@
       set_fact:
         __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if host is booted
+  # noqa command-instead-of-module
+  command: systemctl is-system-running
+  register: __is_system_running
+  changed_when: false
+  check_mode: false
+  failed_when: false
+
+- name: Require installed systemd
+  fail:
+    msg: "Error: This role requires systemd to be installed."
+  when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+- name: Set flag to indicate that systemd runtime operations are available
+  set_fact:
+    __grafana_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
+
 - name: Install Grafana packages
   package:
     name: "{{ __grafana_packages + __grafana_packages_extra }}"
@@ -72,7 +89,7 @@
 - name: Ensure graphing service is running and enabled on boot
   service:
     name: grafana-server
-    state: started
+    state: "{{ 'started' if __grafana_is_booted else omit }}"
     enabled: true
 
 # yamllint disable rule:line-length

--- a/roles/keyserver/handlers/main.yml
+++ b/roles/keyserver/handlers/main.yml
@@ -5,3 +5,4 @@
   service:
     name: "{{ __keyserver_name }}"
     state: restarted
+  when: __keyserver_is_booted | bool

--- a/roles/keyserver/tasks/main.yml
+++ b/roles/keyserver/tasks/main.yml
@@ -28,6 +28,23 @@
       set_fact:
         __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if host is booted
+  # noqa command-instead-of-module
+  command: systemctl is-system-running
+  register: __is_system_running
+  changed_when: false
+  check_mode: false
+  failed_when: false
+
+- name: Require installed systemd
+  fail:
+    msg: "Error: This role requires systemd to be installed."
+  when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+- name: Set flag to indicate that systemd runtime operations are available
+  set_fact:
+    __keyserver_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
+
 - name: Install key server packages
   package:
     name: "{{ __keyserver_packages + __keyserver_packages_extra }}"
@@ -68,5 +85,5 @@
 - name: Ensure key server service is running and enabled on boot
   service:
     name: "{{ __keyserver_name }}"
-    state: started
+    state: "{{ 'started' if __keyserver_is_booted else omit }}"
     enabled: true

--- a/roles/pcp/handlers/main.yml
+++ b/roles/pcp/handlers/main.yml
@@ -5,18 +5,22 @@
   service:
     name: pmcd
     state: restarted
+  when: __pcp_is_booted | bool
 
 - name: Restart pmie
   service:
     name: pmie
     state: restarted
+  when: __pcp_is_booted | bool
 
 - name: Restart pmproxy
   service:
     name: pmproxy
     state: restarted
+  when: __pcp_is_booted | bool
 
 - name: Restart pmlogger
   service:
     name: pmlogger
     state: restarted
+  when: __pcp_is_booted | bool

--- a/roles/pcp/tasks/main.yml
+++ b/roles/pcp/tasks/main.yml
@@ -24,6 +24,26 @@
       set_fact:
         __ansible_pcp_is_ostree: "{{ __ostree_booted_stat.stat.exists }}"
 
+- name: Determine if host is booted
+  when: __pcp_is_booted is not defined
+  block:
+    - name: Run systemctl
+      # noqa command-instead-of-module
+      command: systemctl is-system-running
+      register: __is_system_running
+      changed_when: false
+      check_mode: false
+      failed_when: false
+
+    - name: Require installed systemd
+      fail:
+        msg: "Error: This role requires systemd to be installed."
+      when: '"No such file or directory" in __is_system_running.msg | d("")'
+
+    - name: Set flag to indicate that systemd runtime operations are available
+      set_fact:
+        __pcp_is_booted: "{{ __is_system_running.stdout != 'offline' }}"
+
 - name: Install Performance Co-Pilot packages
   package:
     name: "{{ __pcp_packages + __pcp_packages_extra + pcp_optional_packages }}"

--- a/roles/pcp/tasks/pmcd.yml
+++ b/roles/pcp/tasks/pmcd.yml
@@ -116,13 +116,13 @@
 - name: Ensure performance metric collector is running and enabled on boot
   service:
     name: pmcd
-    state: started
+    state: "{{ 'started' if __pcp_is_booted else omit }}"
     enabled: true
   when: not __pcp_restart_pmcd | bool
 
 - name: Ensure performance metric collector is restarted and enabled on boot
   service:
     name: pmcd
-    state: restarted
+    state: "{{ 'restarted' if __pcp_is_booted else omit }}"
     enabled: true
   when: __pcp_restart_pmcd | bool

--- a/roles/pcp/tasks/pmie.yml
+++ b/roles/pcp/tasks/pmie.yml
@@ -127,13 +127,13 @@
 - name: Ensure performance metric inference is running and enabled on boot
   service:
     name: pmie
-    state: started
+    state: "{{ 'started' if __pcp_is_booted else omit }}"
     enabled: true
   when: not __pcp_restart_pmie | bool
 
 - name: Ensure performance metric inference is restarted and enabled on boot
   service:
     name: pmie
-    state: restarted
+    state: "{{ 'restarted' if __pcp_is_booted else omit }}"
     enabled: true
   when: __pcp_restart_pmie | bool

--- a/roles/pcp/tasks/pmlogger.yml
+++ b/roles/pcp/tasks/pmlogger.yml
@@ -58,13 +58,13 @@
 - name: Ensure performance metric logging is running and enabled on boot
   service:
     name: pmlogger
-    state: started
+    state: "{{ 'started' if __pcp_is_booted else omit }}"
     enabled: true
   when: not __pcp_restart_pmlogger | bool
 
 - name: Ensure performance metric logging is restarted and enabled on boot
   service:
     name: pmlogger
-    state: restarted
+    state: "{{ 'restarted' if __pcp_is_booted else omit }}"
     enabled: true
   when: __pcp_restart_pmlogger | bool

--- a/roles/pcp/tasks/pmproxy.yml
+++ b/roles/pcp/tasks/pmproxy.yml
@@ -11,5 +11,5 @@
 - name: Ensure REST API, proxy and log discovery is running and enabled on boot
   service:
     name: pmproxy
-    state: started
+    state: "{{ 'started' if __pcp_is_booted else omit }}"
     enabled: true

--- a/roles/spark/tasks/main.yml
+++ b/roles/spark/tasks/main.yml
@@ -84,10 +84,23 @@
     - spark_metrics_provider == 'pcp'
     - spark_export_metrics | d(false) | bool
 
+- name: Determine if host is booted
+  # noqa command-instead-of-module
+  command: systemctl is-system-running
+  register: __system_running
+  changed_when: false
+  check_mode: false
+  failed_when: false
+
+- name: Require installed systemd
+  fail:
+    msg: "Error: This role requires systemd to be installed."
+  when: '"No such file or directory" in __system_running.msg | d("")'
+
 - name: Ensure PCP Spark export is running and enabled on boot
   service:
     name: pcp2spark
-    state: started
+    state: "{{ 'started' if __system_running.stdout != 'offline' else omit }}"
     enabled: true
   # A given Spark server may be running remotely or presently down
   # but since a playbook has explicitly asked us for it, we end up


### PR DESCRIPTION
When running the role against a buildah or non-system podman host (e.g. as part of creating a bootc image), services can't actually start. So skip these runtime operations and just enable the services on-disk.

---

Tested in https://github.com/linux-system-roles/metrics/pull/243