### PR TITLE
feat: add support for grafana_cert and grafana_private_key for grafana https

### DIFF
--- a/roles/grafana/defaults/main.yml
+++ b/roles/grafana/defaults/main.yml
@@ -1,2 +1,4 @@
 # SPDX-License-Identifier: MIT
 ---
+grafana_cert: ""
+grafana_private_key: ""

--- a/roles/grafana/tasks/main.yml
+++ b/roles/grafana/tasks/main.yml
@@ -86,6 +86,24 @@
     mode: "0644"
   notify: Restart grafana
 
+- name: Ensure Grafana certificate is owned by grafana
+  file:
+    path: "{{ grafana_cert }}"
+    state: file
+    group: grafana
+    owner: grafana
+    mode: "0640"
+  when: grafana_cert | length > 0
+
+- name: Ensure Grafana private key is owned by grafana
+  file:
+    path: "{{ grafana_private_key }}"
+    state: file
+    group: grafana
+    owner: grafana
+    mode: "0600"
+  when: grafana_private_key | length > 0
+
 - name: Ensure graphing service is running and enabled on boot
   service:
     name: grafana-server

--- a/roles/grafana/templates/grafana_7.ini.j2
+++ b/roles/grafana/templates/grafana_7.ini.j2
@@ -31,7 +31,11 @@ provisioning = {{ __grafana_provisioning_path }}
 #################################### Server ##############################
 [server]
 # Protocol (http, https, h2, socket)
+{% if grafana_cert | d("") | length > 0 and grafana_private_key | d("") | length > 0 %}
+protocol = https
+{% else %}
 protocol = http
+{% endif %}
 
 # The ip address to bind to, empty will bind to all interfaces
 http_addr =
@@ -62,8 +66,16 @@ static_root_path = public
 enable_gzip = false
 
 # https certs & key file
+{% if grafana_cert | d("") | length > 0 %}
+cert_file = {{ grafana_cert }}
+{% else %}
 cert_file =
+{% endif %}
+{% if grafana_private_key | d("") | length > 0 %}
+cert_key = {{ grafana_private_key }}
+{% else %}
 cert_key =
+{% endif %}
 
 # Unix socket path
 socket = /tmp/grafana.sock

--- a/roles/grafana/templates/grafana_9.ini.j2
+++ b/roles/grafana/templates/grafana_9.ini.j2
@@ -34,7 +34,11 @@ provisioning = {{ __grafana_provisioning_path }}
 #################################### Server ####################################
 [server]
 # Protocol (http, https, h2, socket)
+{% if grafana_cert | d("") | length > 0 and grafana_private_key | d("") | length > 0 %}
+protocol = https
+{% else %}
 ;protocol = http
+{% endif %}
 
 # The ip address to bind to, empty will bind to all interfaces
 ;http_addr =
@@ -66,8 +70,16 @@ provisioning = {{ __grafana_provisioning_path }}
 ;enable_gzip = false
 
 # https certs & key file
+{% if grafana_cert | d("") | length > 0 %}
+cert_file = {{ grafana_cert }}
+{% else %}
 ;cert_file =
+{% endif %}
+{% if grafana_private_key | d("") | length > 0 %}
+cert_key = {{ grafana_private_key }}
+{% else %}
 ;cert_key =
+{% endif %}
 
 # Unix socket path
 ;socket =


### PR DESCRIPTION
Users can pass in grafana_cert and grafana_private_key to enable grafana HTTPS.
These are the absolute paths to the files on the managed node.  The user is
responsible for ensuring that the files exist.  If you want to automate
the cert/key file management, use something like IdM and certmonger, or
use the metrics system role.

Signed-off-by: Rich Megginson <rmeggins@redhat.com>
