### PR TITLE
fix: avoid double restart of pmlogger on config changes

### DIFF
--- a/roles/pcp/handlers/main.yml
+++ b/roles/pcp/handlers/main.yml
@@ -18,9 +18,3 @@
     name: pmproxy
     state: restarted
   when: __pcp_is_booted | bool
-
-- name: Restart pmlogger
-  service:
-    name: pmlogger
-    state: restarted
-  when: __pcp_is_booted | bool

--- a/roles/pcp/tasks/pmlogger.yml
+++ b/roles/pcp/tasks/pmlogger.yml
@@ -22,7 +22,6 @@
     dest: "{{ __pcp_pmlogger_timers_path }}"
     mode: "0644"
   register: __pcp_register_changed_logging_retention_period
-  notify: Restart pmlogger
 
 - name: Enable performance metric logging for targeted hosts (with control.d)
   template:
@@ -31,7 +30,6 @@
     mode: "0644"
   loop: "{{ pcp_target_hosts | default([]) }}"
   register: __pcp_register_changed_targeted_hosts_controld
-  notify: Restart pmlogger
   when:
     - not pcp_single_control | d(false) | bool
     - pcp_target_hosts | d([]) | length > 0


### PR DESCRIPTION
The pmlogger timers and control.d tasks notified a handler to restart pmlogger, but those same changes already set __pcp_restart_pmlogger and triggered a restart in the main service task. On first playbook run this could restart pmlogger twice in quick succession, causing systemd to fail the second start on Type=notify services.
Drop the redundant handler notifications and the Restart pmlogger handler; rely on the existing restart task, consistent with pmie.

Resolves: [RHEL-182971](https://redhat.atlassian.net/browse/RHEL-182971)